### PR TITLE
Change method for passing token

### DIFF
--- a/lib/lolp/connection.rb
+++ b/lib/lolp/connection.rb
@@ -26,7 +26,7 @@ module Lolp
     private
 
     def connection
-      Faraday.new(url: config.api_endpoint, headers: { Authorization: @token }) do |faraday|
+      Faraday.new(url: config.api_endpoint, headers: { Authorization: "Bearer #{@token}" }) do |faraday|
         faraday.request :json
         faraday.response :json, content_type: /\bjson$/
         faraday.response :logger


### PR DESCRIPTION
表題の通りです。`Authorization: Bearer` ヘッダにトークンを渡すように変更があったので対応しました。