### PR TITLE
Add custom domains

### DIFF
--- a/lib/lolp/project.rb
+++ b/lib/lolp/project.rb
@@ -11,5 +11,13 @@ module Lolp
     def delete_project(name)
       connection.delete("projects/#{name}")
     end
+
+    def create_custom_domain(domain, custom_domain)
+      connection.post("projects/#{domain}/custom-domains", domain: custom_domain)
+    end
+
+    def delete_custom_domain(domain, custom_domain)
+      connection.delete("projects/#{domain}/custom-domains/#{custom_domain}")
+    end
   end
 end

--- a/test/fixtures/vcr_cassettes/create_custom_domain.yml
+++ b/test/fixtures/vcr_cassettes/create_custom_domain.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://staging.mc.lolipop.jp/api/projects/jolly-hirado-0217.staging.lolipop.io/custom-domains
+    body:
+      encoding: UTF-8
+      string: '{"domain":"example.com"}'
+    headers:
+      Authorization:
+      - Bearer <TOKEN>
+      User-Agent:
+      - Faraday v0.13.1
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: 
+    headers:
+      date:
+      - Mon, 20 Nov 2017 06:27:22 GMT
+      connection:
+      - close
+      content-length:
+      - '7'
+      server:
+      - h2o/2.2.2
+      content-type:
+      - text/plain; charset=utf-8
+      access-control-allow-origin:
+      - "*"
+      access-control-allow-headers:
+      - Origin, X-Requested-With, Content-Type, Accept
+      x-ohr-status:
+      - s, 11461, 20171120-060338.702, 1425.272
+      etag:
+      - W/"7-rM9AyJuqT6iOan/xHh+AW+7K/T8"
+      front-end-https:
+      - 'on'
+    body:
+      encoding: UTF-8
+      string: Created
+    http_version: 
+  recorded_at: Mon, 20 Nov 2017 06:27:19 GMT
+recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/create_custom_domain_faild.yml
+++ b/test/fixtures/vcr_cassettes/create_custom_domain_faild.yml
@@ -1,0 +1,44 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://staging.mc.lolipop.jp/api/projects/invalid_domain/custom-domains
+    body:
+      encoding: UTF-8
+      string: '{"domain":"example.com"}'
+    headers:
+      Authorization:
+      - Bearer <TOKEN>
+      User-Agent:
+      - Faraday v0.13.1
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 500
+      message: 
+    headers:
+      date:
+      - Mon, 20 Nov 2017 06:28:44 GMT
+      connection:
+      - close
+      content-length:
+      - '21'
+      server:
+      - h2o/2.2.2
+      content-type:
+      - text/plain; charset=utf-8
+      access-control-allow-origin:
+      - "*"
+      access-control-allow-headers:
+      - Origin, X-Requested-With, Content-Type, Accept
+      x-ohr-status:
+      - s, 11431, 20171120-060336.723, 1509.693
+      etag:
+      - W/"15-/6VXivhc2MKdLfIkLcUE47K6aH0"
+    body:
+      encoding: UTF-8
+      string: Internal Server Error
+    http_version: 
+  recorded_at: Mon, 20 Nov 2017 06:28:41 GMT
+recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/delete_custom_domain.yml
+++ b/test/fixtures/vcr_cassettes/delete_custom_domain.yml
@@ -1,0 +1,40 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://staging.mc.lolipop.jp/api/projects/jolly-hirado-0217.staging.lolipop.io/custom-domains/example.com
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <TOKEN>
+      User-Agent:
+      - Faraday v0.13.1
+  response:
+    status:
+      code: 204
+      message: 
+    headers:
+      date:
+      - Mon, 20 Nov 2017 06:34:27 GMT
+      connection:
+      - close
+      server:
+      - h2o/2.2.2
+      access-control-allow-origin:
+      - "*"
+      access-control-allow-headers:
+      - Origin, X-Requested-With, Content-Type, Accept
+      x-ohr-status:
+      - s, 11461, 20171120-060338.702, 1850.759
+      etag:
+      - W/"a-bAsFyilMr4Ra1hIU5PyoyFRunpI"
+      front-end-https:
+      - 'on'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 20 Nov 2017 06:34:24 GMT
+recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/delete_custom_domain_faild.yml
+++ b/test/fixtures/vcr_cassettes/delete_custom_domain_faild.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://staging.mc.lolipop.jp/api/projects/invalid_domain/custom-domains/example.com
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <TOKEN>
+      User-Agent:
+      - Faraday v0.13.1
+  response:
+    status:
+      code: 500
+      message: 
+    headers:
+      date:
+      - Mon, 20 Nov 2017 06:33:26 GMT
+      connection:
+      - close
+      content-length:
+      - '21'
+      server:
+      - h2o/2.2.2
+      content-type:
+      - text/plain; charset=utf-8
+      access-control-allow-origin:
+      - "*"
+      access-control-allow-headers:
+      - Origin, X-Requested-With, Content-Type, Accept
+      x-ohr-status:
+      - s, 11461, 20171120-060338.702, 1789.265
+      etag:
+      - W/"15-/6VXivhc2MKdLfIkLcUE47K6aH0"
+    body:
+      encoding: UTF-8
+      string: Internal Server Error
+    http_version: 
+  recorded_at: Mon, 20 Nov 2017 06:33:23 GMT
+recorded_with: VCR 3.0.3

--- a/test/project_test.rb
+++ b/test/project_test.rb
@@ -49,4 +49,36 @@ class ProjectTest < Minitest::Test
       assert_equal 'Internal Server Error', response.body
     end
   end
+
+  def test_create_custom_domain
+    VCR.use_cassette('create_custom_domain') do
+      response = Lolp.create_custom_domain('jolly-hirado-0217.staging.lolipop.io', 'example.com')
+      assert_equal 201, response.status
+      assert_equal 'Created', response.body
+    end
+  end
+
+  def test_create_custom_domain_faild
+    VCR.use_cassette('create_custom_domain_faild') do
+      response = Lolp.create_custom_domain('invalid_domain', 'example.com')
+      assert_equal 500, response.status
+      assert_equal 'Internal Server Error', response.body
+    end
+  end
+
+  def test_delete_custom_domain
+    VCR.use_cassette('delete_custom_domain') do
+      response = Lolp.delete_custom_domain('jolly-hirado-0217.staging.lolipop.io', 'example.com')
+      assert_equal 204, response.status
+      assert_equal '', response.body
+    end
+  end
+
+  def test_delete_custom_domain_faild
+    VCR.use_cassette('delete_custom_domain_faild') do
+      response = Lolp.delete_custom_domain('invalid_domain', 'example.com')
+      assert_equal 500, response.status
+      assert_equal 'Internal Server Error', response.body
+    end
+  end
 end


### PR DESCRIPTION
カスタムドメインのAPIを叩けるようにします 🖐 

- POST /api/projects/:domain/custom-domains
- DELETE /api/projects/:domain/custom-domains/:customDomain

```rb
Lolp.create_custom_domain('jungly-naha-2778.lolipop.ohr','orzup-test.com')
Lolp.delete_custom_domain('jungly-naha-2778.lolipop.ohr','orzup-test.com')
```