### PR TITLE
Chenge api endpoint

### DIFF
--- a/lib/lolp/configuration.rb
+++ b/lib/lolp/configuration.rb
@@ -12,7 +12,7 @@ module Lolp
       attr_accessor :api_endpoint, :username, :password
 
       def initialize
-        @api_endpoint = ENV['LOLIPOP_MC_API_ENDPOINT'] || 'https://mc.lolipop.jp/api'
+        @api_endpoint = ENV['LOLIPOP_MC_API_ENDPOINT'] || 'https://api.mc.lolipop.jp/v1'
         @username = ENV['LOLIPOP_MC_USERNAME']
         @password = ENV['LOLIPOP_MC_PASSWORD']
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,7 +4,7 @@ require 'minitest/autorun'
 require 'vcr'
 
 Lolp.configure do |config|
-  config.api_endpoint = 'https://mc.lolipop.jp/api'
+  config.api_endpoint = 'https://api.mc.lolipop.jp/v1'
 end
 
 VCR.configure do |config|


### PR DESCRIPTION
|  | from | to |
| --- | --- | --- |
| URL | https://mc.lolipop.jp/api | https://api.mc.lolipop.jp/v1 |
| login path | `/login` | `/authenticate` |


