### PR TITLE
Get a auth token every time before request

### DIFF
--- a/lib/lolp/connection.rb
+++ b/lib/lolp/connection.rb
@@ -29,7 +29,7 @@ module Lolp
     end
 
     def auto_loginable?(url)
-      !authenticated? && url !~ /\/authenticate/ && @username && @password
+      url !~ /\/authenticate/ && @username && @password
     end
 
     def request(method, url = nil, data = nil, headers = nil, &block)

--- a/lib/lolp/version.rb
+++ b/lib/lolp/version.rb
@@ -1,3 +1,3 @@
 module Lolp
-  VERSION = '0.8.1'
+  VERSION = '0.8.2'
 end


### PR DESCRIPTION
No implementation to refresh auth token when expired it, now.
And MC has no API to check auth token validation.
So, I want to get auth token every time before request to avoid auth token expired error.
```
[1] pry(#<Lolp::Client>)> Lolp.project('example-project-0000')
Lolp::Forbidden: GET https://staging-api.mc.lolipop.jp/v1/projects/example-project-0000: 403 - {"errors"=>["require authentication"], "requireLogin"=>true, "requireReload"=>false}
```